### PR TITLE
feat(TASK-001): Repository Bootstrap & README Quickstart

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment variables for development. DO NOT store real secrets here.
+DEBUG=true
+SECRET_KEY=replace-me
+DATABASE_URL=mongodb://localhost:27017/finance_app
+REDIS_URL=redis://localhost:6379/0
+JWT_SECRET=replace-me
+ENCRYPTION_KEY=replace-me

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.py text eol=lf
+*.md text
+*.yaml text

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
-.DS_Store
+# Python
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+venv/
 .env
+.env.local
+# IDEs
+.vscode/
+.idea/
+# Docker
+docker-compose.override.yml
+# Logs
+*.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: bootstrap run
+bootstrap:
+	./scripts/bootstrap.sh
+
+run:
+	./scripts/run-local.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# AI-Generated Finance App
+
+Repository bootstrap and developer quickstart (TASK-001)
+
+This project is a Personal Finance Tracker API. This branch implements the TASK-001 bootstrap: a minimal developer-friendly skeleton so contributors can run a local stub server and follow a reproducible quickstart.
+
+Prerequisites
+- Python 3.11+
+- Git
+- Docker (optional)
+
+Quickstart (local, recommended)
+1. Copy environment file:
+   cp .env.example .env
+   # Edit .env and fill values as needed (no real secrets should be committed)
+
+2. Bootstrap the developer environment (creates a virtualenv and installs dependencies):
+   ./scripts/bootstrap.sh
+
+3. Start the local server:
+   ./scripts/run-local.sh
+
+4. Verify the health endpoint:
+   curl http://localhost:8000/health
+
+Files added in this task
+- README.md - this quickstart
+- .env.example - example environment variables (no secrets)
+- .gitignore, .gitattributes, .editorconfig
+- app/main.py - minimal FastAPI app exposing /health and OpenAPI docs
+- scripts/bootstrap.sh - sets up virtualenv and installs requirements
+- scripts/run-local.sh - runs uvicorn with the app
+- requirements.txt - pinned minimal dependencies
+- Makefile - convenience commands
+
+Notes
+- This is intentionally lightweight and does not implement the full application described in docs/. It provides a reproducible on-ramp for contributors.
+- Follow-up tasks will scaffold the full Django/DRF app per the ADR and OpenAPI spec.
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="AI Generated Finance App - Stub")
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.95.1
+uvicorn[standard]==0.22.0
+python-dotenv==1.0.0

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Bootstrap complete. Activate with: source .venv/bin/activate"

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source .venv/bin/activate || true
+uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This PR implements TASK-001: adds a repo bootstrap with a minimal FastAPI stub, README quickstart, env example, and helper scripts.

Files added:
- README.md
- .env.example
- .gitignore
- .gitattributes
- .editorconfig
- app/main.py
- scripts/bootstrap.sh
- scripts/run-local.sh
- requirements.txt
- Makefile

This provides a reproducible developer on-ramp for the project and is intentionally lightweight. Follow-up tasks will scaffold the full application per the docs/ OpenAPI.
